### PR TITLE
Adding context-sensitive callbacks for tcp and udp listeners, and the li...

### DIFF
--- a/src/net/jnxsocket.h
+++ b/src/net/jnxsocket.h
@@ -44,10 +44,12 @@ extern "C" {
    *@warning must return 0 or will break the listener loop
    */
   typedef jnx_int32 (*tcp_socket_listener_callback)(jnx_uint8 *payload, jnx_size bytesread, jnx_socket *s);
+  typedef jnx_int32 (*tcp_socket_listener_callback_with_context)(jnx_uint8 *payload, jnx_size bytesread, jnx_socket *s, void *context);
   /*
    *@warning must return 0 or will break the listener loop
    */
   typedef jnx_int32 (*udp_socket_listener_callback)(jnx_uint8 *payload, jnx_size bytesread, jnx_socket *s);
+  typedef jnx_int32 (*udp_socket_listener_callback_with_context)(jnx_uint8 *payload, jnx_size bytesread, jnx_socket *s, void *context);
   /**
    * @fn jnx_socket *jnx_socket_tcp_create(jnx_unsigned_int addrfamily)
    * @brief creates a jnx tcp socket
@@ -148,6 +150,27 @@ extern "C" {
    * @return -1 on error
    */
   int jnx_socket_udp_listen(jnx_socket *s, jnx_char* port, jnx_size max_connections, udp_socket_listener_callback c);
+  /**
+   * @fn jnx_int32 jnx_socket_tpc_listen(jnx_socket *s, jnx_char* port, jnx_size max_connections, socket_listener_callback c)
+   * @param s is the socket to use to send
+   * @param port is the target port
+   * @param max_connections are the number of connetions in the queue
+   * @param c is the function pointer callback for received messages
+   * @param context is the data to pass to the callback as contextual information
+   * @return -1 on error
+   */
+  int jnx_socket_tcp_listen_with_context(jnx_socket *s, jnx_char* port, jnx_size max_connections, tcp_socket_listener_callback_with_context c, void *context);
+  /**
+   * @fn jnx_int32 jnx_socket_udp_listen(jnx_socket *s, jnx_char* port, jnx_size max_connections, socket_listener_callback c)
+   * @param s is the socket to use to send
+   * @param port is the target port
+   * @param max_connections are the number of connetions in the queue
+   * @param c is the function pointer callback for received messages
+   * @param context is the data to pass to the callback as contextual information
+   * @return -1 on error
+   */
+  int jnx_socket_udp_listen_with_context(jnx_socket *s, jnx_char* port, jnx_size max_connections, udp_socket_listener_callback_with_context c, void *context);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
...stener functions that use them.

We need to be able to pass some context into the callbacks in case we want to avoid statics, for example in the discovery service, I'll need to update the peer store which will be a field in discovery_service struct, so in order to do it without globals I need to pass in the discovery service pointer to the callback.

I've reused your code for tcp_listen and udp_listen, and I've wrapped the *_with_context functions to which I pass NULL context, to produce the same behaviour as before.

All tests pass.

Can you review it, and if you're happy merge it and also update the Git submodule reference in whisper.

Cheers

Dragan