### PR TITLE
Changing callback type defines for unix sockets so that we can avoid nam...

### DIFF
--- a/src/ipc/jnxunixsocket.h
+++ b/src/ipc/jnxunixsocket.h
@@ -20,8 +20,8 @@
  *
  *  #include <jnxc_headers/jnxunixsocket.h>
  */
-#ifndef __JNXSOCKET_H__
-#define __JNXSOCKET_H__
+#ifndef __JNXUNIXSOCKET_H__
+#define __JNXUNIXSOCKET_H__
 #include "jnxtypes.h"
 #include <stddef.h>
 #include <sys/types.h>


### PR DESCRIPTION
...e clashes if we include both sockets and unix sockets in the same .c file.